### PR TITLE
Change AmPointerInfo to class to fix warning

### DIFF
--- a/include/hc_am.hpp
+++ b/include/hc_am.hpp
@@ -16,7 +16,8 @@ typedef int am_status_t;
 namespace hc {
 
 // Info for each pointer in the memtry tracker:
-struct AmPointerInfo {
+class AmPointerInfo {
+public:
     void *      _hostPointer;   ///< Host pointer.  If host access is not allowed, NULL.
     void *      _devicePointer; ///< Device pointer.  
     size_t      _sizeBytes;     ///< Size of allocation.


### PR DESCRIPTION
This PR fixes the following warning message:
/opt/rocm/hcc/include/hc_am.hpp:19:1: warning: 'AmPointerInfo' defined as a struct here but previously declared as a class [-Wmismatched-tags]
struct AmPointerInfo {
^
/opt/rocm/hcc/include/hc.hpp:47:1: note: did you mean struct here?
class AmPointerInfo;
^~~~~
struct
/opt/rocm/hcc/include/kalmar_runtime.h:7:1: note: did you mean struct here?
class AmPointerInfo;
^~~~~
struct